### PR TITLE
Adds ability to validate VIN w/ lowercase characters

### DIFF
--- a/lib/vindetta/calculator.rb
+++ b/lib/vindetta/calculator.rb
@@ -1,8 +1,14 @@
 module Vindetta
   class Calculator
+    InvalidCharacterError = Class.new(StandardError)
+
     def self.check_digit(vin)
       transliterator = -> (c) do
-        "0123456789.ABCDEFGH..JKLMN.P.R..STUVWXYZ".chars.index(c) % 10
+        index = "0123456789.ABCDEFGH..JKLMN.P.R..STUVWXYZ".chars.index(c)
+
+        raise InvalidCharacterError if index.nil?
+
+         index % 10
       end
 
       summer = -> (sum, (a, b)) do

--- a/lib/vindetta/validator.rb
+++ b/lib/vindetta/validator.rb
@@ -4,6 +4,8 @@ module Vindetta
       return false unless vin.length == Vindetta::VIN_LENGTH
 
       Calculator.check_digit(vin) == Decoder.vin(vin)[:check_digit]
+    rescue Calculator::InvalidCharacterError
+        false
     end
 
     def self.wmi(wmi)

--- a/spec/vindetta/calculator_spec.rb
+++ b/spec/vindetta/calculator_spec.rb
@@ -2,7 +2,17 @@ require "spec_helper"
 
 RSpec.describe Vindetta::Calculator do
   describe ".check_digit" do
-    it { expect(described_class.check_digit("11111111111111111")).to eq("1") }
-    it { expect(described_class.check_digit("TWB1ZH3B579BHZXWS")).to eq("X") }
+    describe "with valid VIN" do
+      it { expect(described_class.check_digit("11111111111111111")).to eq("1") }
+      it { expect(described_class.check_digit("TWB1ZH3B579BHZXWS")).to eq("X") }
+    end
+
+    describe "with invalid VIN" do
+      it "raises " do
+        expect {
+          described_class.check_digit("ZACCJBBt0FPB63072")
+        }.to raise_error(described_class::InvalidCharacterError)
+      end
+    end
   end
 end

--- a/spec/vindetta/validator_spec.rb
+++ b/spec/vindetta/validator_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Vindetta::Validator do
     end
 
     context "when invalid" do
+      describe "lowercase" do
+        it { expect(described_class.vin("ZACCJBBt0FPB63072")).to be(false) }
+      end
+
       describe "length" do
         it { expect(described_class.vin("1234")).to be(false) }
       end


### PR DESCRIPTION
This fixes the issue where attempting to validate `ZACCJBBt0FPB63072` would result in 

> error: undefined method `%' for nil:NilClass

This was due to `t` not being a valid character.